### PR TITLE
Remove `match` keyword from class names (atc.) for PHP8.0+ (for version-one breanch)

### DIFF
--- a/doc/01-usage.md
+++ b/doc/01-usage.md
@@ -1,9 +1,10 @@
 # Using with [ElasticSearch/ElasticSearch](https://github.com/elastic/elasticsearch-php)
 First we need to prepare query for what we want to search.
+
 ```php
 $query = new \Spameri\ElasticQuery\ElasticQuery();
 $query->query()->must()->add(
-	new \Spameri\ElasticQuery\Query\Match(
+	new \Spameri\ElasticQuery\Query\ElasticMatch(
 		'name',
 		'Avengers'
 	)

--- a/src/Query/ElasticMatch.php
+++ b/src/Query/ElasticMatch.php
@@ -6,7 +6,7 @@ namespace Spameri\ElasticQuery\Query;
 /**
  * @see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
  */
-class Match implements \Spameri\ElasticQuery\Query\LeafQueryInterface
+class ElasticMatch implements \Spameri\ElasticQuery\Query\LeafQueryInterface
 {
 
 	private string $field;

--- a/tests/SpameriTests/ElasticQuery/ElasticQuery.phpt
+++ b/tests/SpameriTests/ElasticQuery/ElasticQuery.phpt
@@ -49,7 +49,7 @@ class ElasticQuery extends \Tester\TestCase
 
 	public function testCreate() : void
 	{
-		$match = new \Spameri\ElasticQuery\Query\Match(
+		$match = new \Spameri\ElasticQuery\Query\ElasticMatch(
 			'name',
 			'Avengers',
 			1.0,

--- a/tests/SpameriTests/ElasticQuery/Query/ElasticMatch.phpt
+++ b/tests/SpameriTests/ElasticQuery/Query/ElasticMatch.phpt
@@ -5,7 +5,7 @@ namespace SpameriTests\ElasticQuery\Query;
 require_once __DIR__ . '/../../bootstrap.php';
 
 
-class Match extends \Tester\TestCase
+class ElasticMatch extends \Tester\TestCase
 {
 
 	private const INDEX = 'spameri_test_video_match';
@@ -26,7 +26,7 @@ class Match extends \Tester\TestCase
 
 	public function testCreate() : void
 	{
-		$match = new \Spameri\ElasticQuery\Query\Match(
+		$match = new \Spameri\ElasticQuery\Query\ElasticMatch(
 			'name',
 			'Avengers',
 			1.0,
@@ -101,4 +101,4 @@ class Match extends \Tester\TestCase
 
 }
 
-(new Match())->run();
+(new ElasticMatch())->run();


### PR DESCRIPTION
Remove `match` keyword from class names (atc.) for PHP8.0+

***

#### :warning:  **BC breaks: YES**
- Rename class `\Spameri\ElasticQuery\Query\Match` to `\Spameri\ElasticQuery\Query\ElasticMatch`
- Rename class `\SpameriTests\ElasticQuery\Query\Match` to `\SpameriTests\ElasticQuery\Query\ElasticMatch`