### PR TITLE
adding methods for common situations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Composer
         run: make composer
 
-      - if: matrix.php == '7.4' && matrix.elastic == "7.12.1"
+      - if: matrix.php == '7.4' && matrix.elastic == '7.12.1'
         name: Coding standard
         run: make cs
 
-      - if: matrix.php == '7.4' && matrix.elastic == "7.12.1"
+      - if: matrix.php == '7.4' && matrix.elastic == '7.12.1'
         name: PHPStan
         run: make phpstan
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: Package CI
+
+on:
+  pull_request:
+
+jobs:
+  checks:
+    name: Checks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ 7.4 ]
+        elastic: [ 7.12.1, 6.8.15, 5.6.16 ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Start Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: ${{ matrix.elastic }}
+
+      - name: Composer
+        run: make composer
+
+      - if: matrix.php == '7.4' && matrix.elastic == "7.12.1"
+        name: Coding standard
+        run: make cs
+
+      - if: matrix.php == '7.4' && matrix.elastic == "7.12.1"
+        name: PHPStan
+        run: make phpstan
+
+      - if: matrix.php == '7.4'
+        name: Tests
+        run: make tests

--- a/src/Mapping/Settings.php
+++ b/src/Mapping/Settings.php
@@ -72,6 +72,50 @@ class Settings implements \Spameri\ElasticQuery\Entity\ArrayInterface
 	}
 
 
+	public function addMappingFieldKeyword(string $name): void
+	{
+		$this->addMappingField(
+			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
+				$name,
+				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_KEYWORD
+			)
+		);
+	}
+
+
+	public function addMappingFieldFloat(string $name): void
+	{
+		$this->addMappingField(
+			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
+				$name,
+				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_FLOAT
+			)
+		);
+	}
+
+
+	public function addMappingFieldInteger(string $name): void
+	{
+		$this->addMappingField(
+			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
+				$name,
+				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_INTEGER
+			)
+		);
+	}
+
+
+	public function addMappingFieldBoolean(string $name): void
+	{
+		$this->addMappingField(
+			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
+				$name,
+				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_BOOLEAN
+			)
+		);
+	}
+
+
 	public function addMappingFieldObject(\Spameri\ElasticQuery\Mapping\Settings\Mapping\FieldObject $fieldObject): void
 	{
 		$this->mapping->addFieldObject($fieldObject);


### PR DESCRIPTION
#### motivation – Less Code Is More :)  

Prepared methods for common situations – 3 lines of code

```php
$settings->addMappingFieldKeyword(ProductMappingProperty::PROPERTY_ENTITY_ID);
$settings->addMappingFieldKeyword(ProductMappingProperty::PROPERTY_EAN);
$settings->addMappingFieldFloat(ProductMappingProperty::PROPERTY_PRICE_INC_VAT);
```

instead of  18 lines of code

```php
		$settings->addMappingField(
			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
				PROPERTY_ENTITY_ID,
				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_KEYWORD
			)
		);
		$settings->addMappingField(
			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
				PROPERTY_EAN,
				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_KEYWORD
			)
		);
		$settings->addMappingField(
			new \Spameri\ElasticQuery\Mapping\Settings\Mapping\Field(
				PROPERTY_PRICE_INC_VAT,
				\Spameri\Elastic\Model\ValidateMapping\AllowedValues::TYPE_FLOAT
			)
		);
```

