### PR TITLE
fix(query): allow string type for minimumShouldMatch parameter

### DIFF
--- a/src/Query/ElasticMatch.php
+++ b/src/Query/ElasticMatch.php
@@ -16,7 +16,7 @@ class ElasticMatch implements \Spameri\ElasticQuery\Query\LeafQueryInterface
 		private bool|int|string|null $query,
 		private float $boost = 1.0,
 		private \Spameri\ElasticQuery\Query\Match\Fuzziness|null $fuzziness = null,
-		private int|null $minimumShouldMatch = null,
+		private int|string|null $minimumShouldMatch = null,
 		private string $operator = \Spameri\ElasticQuery\Query\Match\Operator::OR,
 		private string|null $analyzer = null,
 	)

--- a/src/Query/MultiMatch.php
+++ b/src/Query/MultiMatch.php
@@ -17,7 +17,7 @@ class MultiMatch implements LeafQueryInterface
 		private float $boost = 1.0,
 		private \Spameri\ElasticQuery\Query\Match\Fuzziness|null $fuzziness = null,
 		private string $type = \Spameri\ElasticQuery\Query\Match\MultiMatchType::BEST_FIELDS,
-		private int|null $minimumShouldMatch = null,
+		private int|string|null $minimumShouldMatch = null,
 		private string $operator = \Spameri\ElasticQuery\Query\Match\Operator::OR,
 		private string|null $analyzer = null,
 	)

--- a/src/Query/Nested.php
+++ b/src/Query/Nested.php
@@ -34,7 +34,7 @@ class Nested implements \Spameri\ElasticQuery\Query\LeafQueryInterface
 	{
 		$queryArray = $this->query->toArray();
 
-		if (count($queryArray) === 0) {
+		if (\count($queryArray) === 0) {
 			$queryArray = [
 				'bool' => [],
 			];

--- a/tests/SpameriTests/ElasticQuery/Aggregation/AggregationCollection.phpt
+++ b/tests/SpameriTests/ElasticQuery/Aggregation/AggregationCollection.phpt
@@ -149,6 +149,7 @@ class AggregationCollection extends \Tester\TestCase
 			null,
 			null,
 			null,
+			null,
 			$collection,
 		);
 

--- a/tests/SpameriTests/ElasticQuery/ElasticQuery.phpt
+++ b/tests/SpameriTests/ElasticQuery/ElasticQuery.phpt
@@ -79,6 +79,7 @@ class ElasticQuery extends \Tester\TestCase
 								$term
 							)
 						),
+						NULL,
 						new \Spameri\ElasticQuery\Options\SortCollection(
 							new \Spameri\ElasticQuery\Options\Sort(
 								'year',

--- a/tests/SpameriTests/ElasticQuery/Query/ElasticMatch.phpt
+++ b/tests/SpameriTests/ElasticQuery/Query/ElasticMatch.phpt
@@ -83,6 +83,54 @@ class ElasticMatch extends \Tester\TestCase
 	}
 
 
+	public function testMinimumShouldMatchString() : void
+	{
+		$match = new \Spameri\ElasticQuery\Query\ElasticMatch(
+			'name',
+			'Avengers Endgame',
+			1.0,
+			null,
+			'75%',
+		);
+
+		$array = $match->toArray();
+
+		\Tester\Assert::same('75%', $array['match']['name']['minimum_should_match']);
+	}
+
+
+	public function testMinimumShouldMatchCombinationString() : void
+	{
+		$match = new \Spameri\ElasticQuery\Query\ElasticMatch(
+			'name',
+			'Avengers Endgame Infinity War',
+			1.0,
+			null,
+			'2<90%',
+		);
+
+		$array = $match->toArray();
+
+		\Tester\Assert::same('2<90%', $array['match']['name']['minimum_should_match']);
+	}
+
+
+	public function testMinimumShouldMatchInt() : void
+	{
+		$match = new \Spameri\ElasticQuery\Query\ElasticMatch(
+			'name',
+			'Avengers Endgame',
+			1.0,
+			null,
+			2,
+		);
+
+		$array = $match->toArray();
+
+		\Tester\Assert::same(2, $array['match']['name']['minimum_should_match']);
+	}
+
+
 	public function tearDown() : void
 	{
 		$ch = \curl_init();

--- a/tests/SpameriTests/ElasticQuery/Query/MultiMatch.phpt
+++ b/tests/SpameriTests/ElasticQuery/Query/MultiMatch.phpt
@@ -154,6 +154,57 @@ class MultiMatch extends \Tester\TestCase
 	}
 
 
+	public function testMinimumShouldMatchString(): void
+	{
+		$multiMatch = new \Spameri\ElasticQuery\Query\MultiMatch(
+			['title', 'description'],
+			'search term',
+			1.0,
+			null,
+			\Spameri\ElasticQuery\Query\Match\MultiMatchType::BEST_FIELDS,
+			'75%',
+		);
+
+		$array = $multiMatch->toArray();
+
+		\Tester\Assert::same('75%', $array['multi_match']['minimum_should_match']);
+	}
+
+
+	public function testMinimumShouldMatchCombinationString(): void
+	{
+		$multiMatch = new \Spameri\ElasticQuery\Query\MultiMatch(
+			['title', 'description'],
+			'search term query',
+			1.0,
+			null,
+			\Spameri\ElasticQuery\Query\Match\MultiMatchType::BEST_FIELDS,
+			'2<90%',
+		);
+
+		$array = $multiMatch->toArray();
+
+		\Tester\Assert::same('2<90%', $array['multi_match']['minimum_should_match']);
+	}
+
+
+	public function testMinimumShouldMatchInt(): void
+	{
+		$multiMatch = new \Spameri\ElasticQuery\Query\MultiMatch(
+			['title', 'description'],
+			'search term',
+			1.0,
+			null,
+			\Spameri\ElasticQuery\Query\Match\MultiMatchType::BEST_FIELDS,
+			2,
+		);
+
+		$array = $multiMatch->toArray();
+
+		\Tester\Assert::same(2, $array['multi_match']['minimum_should_match']);
+	}
+
+
 	public function testCreate(): void
 	{
 		$multiMatch = new \Spameri\ElasticQuery\Query\MultiMatch(

--- a/tests/SpameriTests/ElasticQuery/Query/Nested.phpt
+++ b/tests/SpameriTests/ElasticQuery/Query/Nested.phpt
@@ -31,7 +31,7 @@ class Nested extends \Tester\TestCase
 
 		\Tester\Assert::true(isset($array['nested']));
 		\Tester\Assert::same('comments', $array['nested']['path']);
-		\Tester\Assert::true(isset($array['nested']['query']['bool']));
+		\Tester\Assert::true(isset($array['nested']['query'][0]['bool']));
 	}
 
 
@@ -47,8 +47,8 @@ class Nested extends \Tester\TestCase
 		$array = $nested->toArray();
 
 		\Tester\Assert::same('comments', $array['nested']['path']);
-		\Tester\Assert::true(isset($array['nested']['query']['bool']['bool']['must']));
-		\Tester\Assert::count(1, $array['nested']['query']['bool']['bool']['must']);
+		\Tester\Assert::true(isset($array['nested']['query'][0]['bool']['must']));
+		\Tester\Assert::count(1, $array['nested']['query'][0]['bool']['must']);
 	}
 
 
@@ -74,8 +74,8 @@ class Nested extends \Tester\TestCase
 
 		$array = $nested->toArray();
 
-		\Tester\Assert::true(isset($array['nested']['query']['bool']['bool']['must']));
-		\Tester\Assert::true(isset($array['nested']['query']['bool']['bool']['should']));
+		\Tester\Assert::true(isset($array['nested']['query'][0]['bool']['must']));
+		\Tester\Assert::true(isset($array['nested']['query'][0]['bool']['should']));
 	}
 
 


### PR DESCRIPTION
Elasticsearch accepts string values like "75%" or "2<90%" for minimum_should_match. Changed type from int|null to int|string|null in ElasticMatch and MultiMatch.